### PR TITLE
Mm/nth dow

### DIFF
--- a/lib/Date/Utility.pm
+++ b/lib/Date/Utility.pm
@@ -861,7 +861,7 @@ sub move_to_nth_dow {
 
     my $dow = $days_to_num{lc $dow_abb} // croak 'Invalid day of week. We got [' . $dow_abb . ']';
 
-    my $dow_first = ($self->day_of_month - $self->day_of_week) % 7;
+    my $dow_first = (7 - ($self->day_of_month - 1 - $self->day_of_week)) % 7;
     my $dom = ($dow + 7 - $dow_first) % 7 + ($nth - 1) * 7 + 1;
 
     return try { Date::Utility->new(join '-', $self->year, $self->month, $dom) };

--- a/t/constructor.t
+++ b/t/constructor.t
@@ -22,7 +22,6 @@ throws_ok { Date::Utility->new("2001-12-44") } qr/Invalid datetime format/,     
 throws_ok { Date::Utility->new("2001-12-31 23:59:61") } qr/Invalid datetime format/,           'not accepting 61 as a value for seconds';
 throws_ok { Date::Utility->new('4-Jun-54') } qr/only supports two-digit years from 1970-2030/, 'No two digit years between 30 and 70';
 throws_ok { Date::Utility->new('fake') } qr/Invalid datetime format/,                          'random string is not a date string';
-
 # Passy stuff
 new_ok('Date::Utility');
 new_ok(
@@ -170,6 +169,19 @@ new_ok(
     'Date::Utility' => [Date::Utility->new('2014-11-11')],
     'new style Date::Utility object'
 );
+
+subtest 'leap years' => sub {
+    throws_ok { Date::Utility->new('2001-02-29') } qr/Day '29' out of range/, 'No leap day in 2001';
+    throws_ok { Date::Utility->new('1900-02-29') } qr/Day '29' out of range/, '... nor in 1900 by the 100 rule';
+    new_ok(
+        'Date::Utility' => ['2000-02-29'],
+        '400 rule for 2000'
+    );
+    new_ok(
+        'Date::Utility' => ['2004-02-29'],
+        '2004'
+    );
+};
 
 Test::NoWarnings::had_no_warnings();
 done_testing;

--- a/t/object_methods.t
+++ b/t/object_methods.t
@@ -109,6 +109,31 @@ subtest 'move_to_nth_dow' => sub {
     is($datetime1->move_to_nth_dow(1,   'THU')->day_of_month,      1,     '... and a first Thursday.');
     throws_ok { $datetime1->move_to_nth_dow(1, 'abc') } qr/Invalid day/, 'Failing for invalid day of week names';
     throws_ok { $datetime1->move_to_nth_dow(1, 7) } qr/Invalid day/,     'Does not handle Sunday as day 7';
+    subtest 'stress test' => sub {
+        my $today = Date::Utility->today;
+        my $d     = Date::Utility->new($today->year . '-' . $today->month . '-01 12:00');
+        my @dow;
+        my $M = '';
+        for (0 .. 4e2 - 1) {
+            unless ($M eq $d->year . $d->month) {
+                $M   = $d->year . $d->month;
+                @dow = ();
+            }
+            $dow[$d->day_of_week]++;
+            foreach my $base (1 .. 20) {
+                my $base_date = Date::Utility->new(join '-', $d->year, $d->month, $base);
+                is +Date::Utility->new(join '-', $d->year, $d->month, $base)->move_to_nth_dow($dow[$d->day_of_week], $d->day_of_week)->date, $d->date,
+                      'Move from '
+                    . $base_date->date . ' to '
+                    . $dow[$d->day_of_week] . ' '
+                    . $d->full_day_name . ' of '
+                    . $d->month_as_string . ' '
+                    . $d->year . ' is '
+                    . $d->date;
+            }
+            $d = $d->plus_time_interval('1d');
+        }
+    };
 };
 
 1;


### PR DESCRIPTION
Here are some leap day tests.  Many other invalid forms are caught by the regex format checker, so only adding these which get caught by the switch to `timegm`.

@mm-binary You can use these if you like to address the feedback from @tfoertsch.
